### PR TITLE
Compilation error fixed

### DIFF
--- a/packetWin7/npf/npf/win_bpf_filter.c
+++ b/packetWin7/npf/npf/win_bpf_filter.c
@@ -31,7 +31,9 @@
  *
  */
 
+#ifndef _WINDLL
 #include "stdafx.h"
+#endif
 
 #ifndef WIN_NT_DRIVER 
 #include <windows.h>


### PR DESCRIPTION
This fix was necessary to compile both driver and Dll/Packet projects.
Tested on VS2010 and VS2015 on multiple machines.