### PR TITLE
Remove symbol redefinition on VS2015

### DIFF
--- a/wpcap/libpcap/pcap/pcap.h
+++ b/wpcap/libpcap/pcap/pcap.h
@@ -37,7 +37,7 @@
 #ifndef lib_pcap_pcap_h
 #define lib_pcap_pcap_h
 
-#if defined(WIN32)
+#if defined(WIN32) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
Since VS2015 has native support for snprintf we don't need to define it.
See more: in comments https://github.com/nmap/npcap/commit/41f34f93