### PR TITLE
Limit buffer size to 1GiB in BIOCSETBUFFERSIZE ioctl calls 

### DIFF
--- a/packetNtx/driver/Packet.c
+++ b/packetNtx/driver/Packet.c
@@ -1364,6 +1364,13 @@ NTSTATUS NPF_IoControl(IN PDEVICE_OBJECT DeviceObject,IN PIRP Irp)
 		// Get the number of bytes to allocate
 		dim = *((PULONG)Irp->AssociatedIrp.SystemBuffer);
 
+		// verify that the provided size value is sensible
+		if (dim > NPF_MAX_BUFFER_SIZE)
+		{
+			SET_FAILURE_NOMEM();
+			break;
+		}
+		
 		if (dim / g_NCpu < sizeof(struct PacketHeader))
 		{
 			dim = 0;

--- a/packetNtx/driver/Packet.h
+++ b/packetNtx/driver/Packet.h
@@ -98,6 +98,8 @@
 #define NPF_DISABLE_LOOPBACK	1	///< Tells the driver to drop the packets sent by itself. This is usefult when building applications like bridges.
 #define NPF_ENABLE_LOOPBACK		2	///< Tells the driver to capture the packets sent by itself.
 
+#define NPF_MAX_BUFFER_SIZE 0x40000000L		// Maximum pool size allowed in bytes (defence against bad BIOCSETBUFFERSIZE calls)
+
 /*!
   \brief Header of a libpcap dump file.
 


### PR DESCRIPTION
At the moment, the BIOCSETBUFFERSIZE ioctl does not enforce an upper bound on the requested buffer size. Buggy usercode can ask for as much memory as it likes, and the driver will oblige as long as the ExAllocatePoolWithTag call succeeds. In the non-admin (unrestricted) install configuration, this could potentially be used as a local unprivileged denial-of-service attack.

This patch introduces an NPF_MAX_BUFFER_SIZE constant (value of 1GiB) which is used as an upper bound on allocation requests. This should at least prevent catastrophic failure on most systems, and limit the impact of malicious usercode abusing the feature.