### PR TITLE
 Limit buffer size to 1GiB in BIOCSETBUFFERSIZE ioctl calls

### DIFF
--- a/packetWin7/npf/npf/Packet.c
+++ b/packetWin7/npf/npf/Packet.c
@@ -1815,6 +1815,13 @@ NPF_IoControl(
 
 		// Get the number of bytes to allocate
 		dim = *((PULONG)Irp->AssociatedIrp.SystemBuffer);
+		
+		// verify that the provided size value is sensible
+		if (dim > NPF_MAX_BUFFER_SIZE)
+		{
+			SET_FAILURE_NOMEM();
+			break;
+		} 
 
 		if (dim / g_NCpu < sizeof(struct PacketHeader))
 		{

--- a/packetWin7/npf/npf/Packet.h
+++ b/packetWin7/npf/npf/Packet.h
@@ -120,6 +120,9 @@ extern NDIS_HANDLE         FilterDriverObject;
 // An example is: \Device\{754FC84C-EFBC-4443-B479-2EFAE01DC7BF};
 #define ADAPTER_NAME_SIZE_WITH_SEPARATOR	(ADAPTER_NAME_SIZE + 1)
 
+// Maximum pool size allowed in bytes (defence against bad BIOCSETBUFFERSIZE calls)
+#define NPF_MAX_BUFFER_SIZE 0x40000000L
+
 /*!
   \brief Header of a libpcap dump file.
 


### PR DESCRIPTION
At the moment, the BIOCSETBUFFERSIZE ioctl does not enforce an upper bound on the requested buffer size. Buggy usercode can ask for as much memory as it likes, and the driver will oblige as long as the ExAllocatePoolWithTag call succeeds. In the non-admin (unrestricted) install configuration, this could potentially be used as a local unprivileged denial-of-service attack.

This patch introduces an NPF_MAX_BUFFER_SIZE constant (value of 1GiB) which is used as an upper bound on allocation requests. This should at least prevent catastrophic failure on most systems, and limit the impact of malicious usercode abusing the feature.

Note: This is a resubmission of https://github.com/nmap/npcap/pull/11 which added the patch to the wrong source directory.