### PR TITLE
0.99-r5 has been released in 2018 rather than 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Npcap 0.99-r5 [2019-05-01]
+## Npcap 0.99-r5 [2018-05-01]
 
 * Restored installer code to silently uninstall WinPcap if silent installation
   in WinPcap API-compatible mode is needed (Npcap OEM only).


### PR DESCRIPTION
I thought I'd lost a year but then I checked my astronomical charts and found that it's still 2018.