### PR TITLE
Use KeQuerySystemTimePrecise if available

### DIFF
--- a/packetWin7/npf/npf/Packet.h
+++ b/packetWin7/npf/npf/Packet.h
@@ -892,6 +892,15 @@ My_KeGetCurrentProcessorNumber(
 
 
 /*!
+\brief Retrieves the current system time.
+\param CurrentTime A pointer to a LARGE_INTEGER variable into which the routine writes the current system time.
+*/
+void
+My_KeQuerySystemTime(
+	PLARGE_INTEGER CurrentTime
+);
+
+/*!
   \brief The initialization routine of the driver.
   \param DriverObject The driver object of NPF created by the system.
   \param RegistryPath The registry path containing the keys related to the driver.

--- a/packetWin7/npf/npf/Packet.h
+++ b/packetWin7/npf/npf/Packet.h
@@ -892,15 +892,6 @@ My_KeGetCurrentProcessorNumber(
 
 
 /*!
-\brief Retrieves the current system time.
-\param CurrentTime A pointer to a LARGE_INTEGER variable into which the routine writes the current system time.
-*/
-void
-My_KeQuerySystemTime(
-	PLARGE_INTEGER CurrentTime
-);
-
-/*!
   \brief The initialization routine of the driver.
   \param DriverObject The driver object of NPF created by the system.
   \param RegistryPath The registry path containing the keys related to the driver.

--- a/packetWin7/npf/npf/time_calls.h
+++ b/packetWin7/npf/npf/time_calls.h
@@ -95,7 +95,12 @@
 
 #define TIMESTAMPMODE_SYNCHRONIZATION_ON_CPU_NO_FIXUP		99
 
+typedef void(*PQUERYSYSTEMTIME)(
+	PLARGE_INTEGER CurrentTime
+	);
+
 extern ULONG g_TimestampMode;
+extern PQUERYSYSTEMTIME g_ptrQuerySystemTime;
 
 /* Defined in Packet.c/h */
 ULONG
@@ -105,12 +110,6 @@ My_NdisGroupMaxProcessorCount(
 /* Defined in Packet.c/h */
 ULONG
 My_KeGetCurrentProcessorNumber(
-);
-
-/* Defined in Packet.c/h */
-void
-My_KeQuerySystemTime(
-	PLARGE_INTEGER CurrentTime
 );
 
 /*!
@@ -160,7 +159,7 @@ __inline void SynchronizeOnCpu(struct timeval* start)
 	// get the absolute value of the system boot time.   
 
 	PTime = KeQueryPerformanceCounter(&TimeFreq);
-	My_KeQuerySystemTime(&SystemTime);
+	g_ptrQuerySystemTime(&SystemTime);
 
 	start->tv_sec = (LONG)(SystemTime.QuadPart / 10000000 - 11644473600);
 
@@ -267,7 +266,7 @@ __inline VOID TimeSynchronizeRDTSC(struct time_conv* data)
 
 	reference = data->reference;
 
-	My_KeQuerySystemTime(&system_time);
+	g_ptrQuerySystemTime(&system_time);
 
 	__asm
 	{
@@ -463,7 +462,7 @@ __inline void GetTimeQST(struct timeval* dst, struct time_conv* data)
 	LARGE_INTEGER SystemTime;
 	UNREFERENCED_PARAMETER(data);
 
-	My_KeQuerySystemTime(&SystemTime);
+	g_ptrQuerySystemTime(&SystemTime);
 
 	dst->tv_sec = (LONG)(SystemTime.QuadPart / 10000000 - 11644473600);
 	dst->tv_usec = (LONG)((SystemTime.QuadPart % 10000000) / 10);

--- a/packetWin7/npf/npf/time_calls.h
+++ b/packetWin7/npf/npf/time_calls.h
@@ -107,6 +107,12 @@ ULONG
 My_KeGetCurrentProcessorNumber(
 );
 
+/* Defined in Packet.c/h */
+void
+My_KeQuerySystemTime(
+	PLARGE_INTEGER CurrentTime
+);
+
 /*!
   \brief A microsecond precise timestamp.
 
@@ -154,7 +160,7 @@ __inline void SynchronizeOnCpu(struct timeval* start)
 	// get the absolute value of the system boot time.   
 
 	PTime = KeQueryPerformanceCounter(&TimeFreq);
-	KeQuerySystemTime(&SystemTime);
+	My_KeQuerySystemTime(&SystemTime);
 
 	start->tv_sec = (LONG)(SystemTime.QuadPart / 10000000 - 11644473600);
 
@@ -261,7 +267,7 @@ __inline VOID TimeSynchronizeRDTSC(struct time_conv* data)
 
 	reference = data->reference;
 
-	KeQuerySystemTime(&system_time);
+	My_KeQuerySystemTime(&system_time);
 
 	__asm
 	{
@@ -457,7 +463,7 @@ __inline void GetTimeQST(struct timeval* dst, struct time_conv* data)
 	LARGE_INTEGER SystemTime;
 	UNREFERENCED_PARAMETER(data);
 
-	KeQuerySystemTime(&SystemTime);
+	My_KeQuerySystemTime(&SystemTime);
 
 	dst->tv_sec = (LONG)(SystemTime.QuadPart / 10000000 - 11644473600);
 	dst->tv_usec = (LONG)((SystemTime.QuadPart % 10000000) / 10);


### PR DESCRIPTION
Get pointer to KeQuerySystemTimePrecise if the Kernel provides it.
Replace calls to KeQuerySystemTime() with calls to a new wrapper
function that dispatches calls to xxxPrecise() if it exists.

On x64 platform, KeQuerySystemTime() is a macro, so it was not possible
to implement this code change with only a function pointer, but a
wrapper function (My_KeQuerySystemTime) was needed.

See nmap/nmap#1407

