### PR TITLE
Reduce number of GetAdaptersAddresses() calls

### DIFF
--- a/packetWin7/Dll/AdInfo.cpp
+++ b/packetWin7/Dll/AdInfo.cpp
@@ -135,6 +135,8 @@ typedef ULONG (WINAPI *GAAHandler)(
 	_Inout_ PIP_ADAPTER_ADDRESSES AdapterAddresses,
 	_Inout_ PULONG                SizePointer);
 extern GAAHandler g_GetAdaptersAddressesPointer;
+#define ADAPTERS_ADDRESSES_INITIAL_BUFFER_SIZE 15000
+#define ADAPTERS_ADDRESSES_MAX_TRIES 3
 
 #ifdef HAVE_AIRPCAP_API
 extern AirpcapGetLastErrorHandler g_PAirpcapGetLastError;
@@ -602,7 +604,9 @@ fail:
 
 static BOOLEAN IsIPv4Enabled(LPCSTR AdapterNameA)
 {
+	ULONG Iterations;
 	ULONG BufLen;
+	DWORD RetVal;
 	PIP_ADAPTER_ADDRESSES AdBuffer, TmpAddr;
 	PCHAR OrName;
 	PIP_ADAPTER_UNICAST_ADDRESS UnicastAddr;
@@ -619,28 +623,38 @@ static BOOLEAN IsIPv4Enabled(LPCSTR AdapterNameA)
 		return TRUE;	// GetAdaptersAddresses() not present on this system,
 	}											// return immediately.
 
- 	if(g_GetAdaptersAddressesPointer(AF_UNSPEC, GAA_FLAG_SKIP_ANYCAST| GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME, NULL, NULL, &BufLen) != ERROR_BUFFER_OVERFLOW)
+	BufLen = ADAPTERS_ADDRESSES_INITIAL_BUFFER_SIZE;
+	Iterations = 0;
+	for (Iterations = 0; Iterations < ADAPTERS_ADDRESSES_MAX_TRIES; Iterations++)
 	{
-		TRACE_PRINT("IsIPv4Enabled: GetAdaptersAddresses Failed while retrieving the needed buffer size");
+		AdBuffer = (PIP_ADAPTER_ADDRESSES)GlobalAllocPtr(GMEM_MOVEABLE, BufLen);
+		if (AdBuffer == NULL)
+		{
+			TRACE_PRINT("IsIPv4Enabled: GlobalAlloc Failed");
+			TRACE_EXIT();
+			return FALSE;
+		}
 
-		TRACE_EXIT();
-		return FALSE;
+		RetVal = g_GetAdaptersAddressesPointer(AF_INET, GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME, NULL, AdBuffer, &BufLen);
+		if (RetVal == ERROR_BUFFER_OVERFLOW)
+		{
+			TRACE_PRINT("IsIPv4Enabled: GetAdaptersAddresses Too small buffer");
+			GlobalFreePtr(AdBuffer);
+			AdBuffer = NULL;
+		}
+		else
+		{
+			break;
+		}
 	}
 
-	TRACE_PRINT("IsIPv4Enabled, retrieved needed storage for the call");
-
-	AdBuffer = (PIP_ADAPTER_ADDRESSES) GlobalAllocPtr(GMEM_MOVEABLE, BufLen);
-	if (AdBuffer == NULL) 
-	{
-		TRACE_PRINT("IsIPv4Enabled: GlobalAlloc Failed");
-		TRACE_EXIT();
-		return FALSE;
-	}
-
- 	if(g_GetAdaptersAddressesPointer(AF_UNSPEC,  GAA_FLAG_SKIP_ANYCAST| GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME, NULL, AdBuffer, &BufLen) != ERROR_SUCCESS)
+	if (RetVal != ERROR_SUCCESS)
 	{
 		TRACE_PRINT("IsIPv4Enabled: GetAdaptersAddresses Failed while retrieving the addresses");
-		GlobalFreePtr(AdBuffer);
+		if (AdBuffer)
+		{
+			GlobalFreePtr(AdBuffer);
+		}
 		TRACE_EXIT();
 		return FALSE;
 	}
@@ -691,7 +705,9 @@ static BOOLEAN IsIPv4Enabled(LPCSTR AdapterNameA)
 */
 static BOOLEAN PacketAddIP6Addresses(PADAPTER_INFO AdInfo)
 {
+	ULONG Iterations;
 	ULONG BufLen;
+	DWORD RetVal;
 	PIP_ADAPTER_ADDRESSES AdBuffer, TmpAddr;
 	PCHAR OrName;
 	PIP_ADAPTER_UNICAST_ADDRESS UnicastAddr;
@@ -714,28 +730,38 @@ static BOOLEAN PacketAddIP6Addresses(PADAPTER_INFO AdInfo)
 		return TRUE;	// GetAdaptersAddresses() not present on this system,
 	}											// return immediately.
 
- 	if(g_GetAdaptersAddressesPointer(AF_UNSPEC, GAA_FLAG_SKIP_ANYCAST| GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME, NULL, NULL, &BufLen) != ERROR_BUFFER_OVERFLOW)
+	BufLen = ADAPTERS_ADDRESSES_INITIAL_BUFFER_SIZE;
+	Iterations = 0;
+	for (Iterations = 0; Iterations < ADAPTERS_ADDRESSES_MAX_TRIES; Iterations++)
 	{
-		TRACE_PRINT("PacketAddIP6Addresses: GetAdaptersAddresses Failed while retrieving the needed buffer size");
+		AdBuffer = (PIP_ADAPTER_ADDRESSES)GlobalAllocPtr(GMEM_MOVEABLE, BufLen);
+		if (AdBuffer == NULL)
+		{
+			TRACE_PRINT("PacketAddIP6Addresses: GlobalAlloc Failed");
+			TRACE_EXIT();
+			return FALSE;
+		}
 
-		TRACE_EXIT();
-		return FALSE;
+		RetVal = g_GetAdaptersAddressesPointer(AF_INET6, GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME, NULL, AdBuffer, &BufLen);
+		if (RetVal == ERROR_BUFFER_OVERFLOW)
+		{
+			TRACE_PRINT("PacketAddIP6Addresses: GetAdaptersAddresses Too small buffer");
+			GlobalFreePtr(AdBuffer);
+			AdBuffer = NULL;
+		}
+		else
+		{
+			break;
+		}
 	}
 
-	TRACE_PRINT("PacketAddIP6Addresses, retrieved needed storage for the call");
-
-	AdBuffer = (PIP_ADAPTER_ADDRESSES) GlobalAllocPtr(GMEM_MOVEABLE, BufLen);
-	if (AdBuffer == NULL) 
+	if (RetVal != ERROR_SUCCESS)
 	{
-		TRACE_PRINT("PacketAddIP6Addresses: GlobalAlloc Failed");
-		TRACE_EXIT();
-		return FALSE;
-	}
-
- 	if(g_GetAdaptersAddressesPointer(AF_UNSPEC,  GAA_FLAG_SKIP_ANYCAST| GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME, NULL, AdBuffer, &BufLen) != ERROR_SUCCESS)
-	{
-		TRACE_PRINT("PacketGetIP6Addresses: GetAdaptersAddresses Failed while retrieving the addresses");
-		GlobalFreePtr(AdBuffer);
+		TRACE_PRINT("PacketAddIP6Addresses: GetAdaptersAddresses Failed while retrieving the addresses");
+		if (AdBuffer)
+		{
+			GlobalFreePtr(AdBuffer);
+		}
 		TRACE_EXIT();
 		return FALSE;
 	}


### PR DESCRIPTION
The GetAdaptersAddresses() calls in Packet.dll take over 70% time needed
for the Wireshark's "dumpcap -D -Z none".

This change addresses the issue by essentially halving the amount of
calls to GetAdaptersAddresses() by calling it first with a preallocated
15000 bytes long buffer. According to GetAdaptersAddresses()
documentation "On typical computers, this dramatically reduces the
chances that the GetAdaptersAddresses function returns
ERROR_BUFFER_OVERFLOW, which would require calling GetAdaptersAddresses
function multiple times".

This change reduces the time "dumpcap -D -Z none" takes by approximately
7.5 seconds. I did 100 time measurements in a row and the results are:
  * with this change: 10.72 seconds average, 2.99 standard deviation
  * without this change: 18.18 seconds average, 4.25 standard deviation