### PR TITLE
Support sending loopback packets as if received on an adapter.

### DIFF
--- a/Common/Packet32.h
+++ b/Common/Packet32.h
@@ -140,6 +140,8 @@ typedef struct _AirpcapHandle* PAirpcapHandle;
 // Loopback behaviour definitions
 #define NPF_DISABLE_LOOPBACK	1	///< Drop the packets sent by the NPF driver
 #define NPF_ENABLE_LOOPBACK		2	///< Capture the packets sent by the NPF driver
+#define NPF_DISABLE_LOOPBACK_RX 3 ///< Do not receive the packets sent by the NPF driver
+#define NPF_ENABLE_LOOPBACK_RX 4 ///< Receive the packets sent by the NPF driver
 
 /*!
   \brief Network type structure.

--- a/packetWin7/Dll/Packet32.cpp
+++ b/packetWin7/Dll/Packet32.cpp
@@ -3928,6 +3928,8 @@ BOOLEAN PacketSetBpf(LPADAPTER AdapterObject, struct bpf_program *fp)
   \param LoopbackBehavior Can be one of the following:
 	- \ref NPF_ENABLE_LOOPBACK
 	- \ref NPF_DISABLE_LOOPBACK
+	- \ref NPF_ENABLE_LOOPBACK_RX (default)
+	- \ref NPF_DISABLE_LOOPBACK_RX
   \return If the function succeeds, the return value is nonzero.
 
   \note: when opened, adapters have loopback capture \b enabled.

--- a/packetWin7/npf/npf/Openclos.c
+++ b/packetWin7/npf/npf/Openclos.c
@@ -1476,6 +1476,7 @@ NPF_CreateOpenObject()
 	Open->Size = 0;
 	Open->SkipSentPackets = FALSE;
 	Open->ReadEvent = NULL;
+	Open->SendFlags = NDIS_SEND_FLAGS_CHECK_FOR_LOOPBACK;
 
 	//
 	// we need to keep a counter of the pending IRPs

--- a/packetWin7/npf/npf/Packet.c
+++ b/packetWin7/npf/npf/Packet.c
@@ -1407,31 +1407,42 @@ NPF_IoControl(
 			break;
 		}
 
-		if (*(PINT) Irp->AssociatedIrp.SystemBuffer == NPF_DISABLE_LOOPBACK)
+		switch(*(PINT)Irp->AssociatedIrp.SystemBuffer)
 		{
-			Open->SkipSentPackets = TRUE;
+			case NPF_DISABLE_LOOPBACK:
+				Open->SkipSentPackets = TRUE;
 
-			//
-			// Reset the capture buffers, since they could contain loopbacked packets
-			//
+				//
+				// Reset the capture buffers, since they could contain loopbacked packets
+				//
 
-			NPF_ResetBufferContents(Open);
+				NPF_ResetBufferContents(Open);
 
-			SET_RESULT_SUCCESS(0);
-			break;
-		}
-		else if (*(PINT) Irp->AssociatedIrp.SystemBuffer == NPF_ENABLE_LOOPBACK)
-		{
-			Open->SkipSentPackets = FALSE;
+				SET_RESULT_SUCCESS(0);
+				break;
 
-			SET_RESULT_SUCCESS(0);
-			break;
-		}
-		else
-		{
-			// Unknown operation
-			SET_FAILURE_INVALID_REQUEST();
-			break;
+			case NPF_ENABLE_LOOPBACK:
+				Open->SkipSentPackets = FALSE;
+
+				SET_RESULT_SUCCESS(0);
+				break;
+
+			case NPF_DISABLE_LOOPBACK_RX:
+				Open->SendFlags &= ~NDIS_SEND_FLAGS_CHECK_FOR_LOOPBACK;
+
+				SET_RESULT_SUCCESS(0);
+				break;
+
+			case NPF_ENABLE_LOOPBACK_RX:
+				Open->SendFlags |= NDIS_SEND_FLAGS_CHECK_FOR_LOOPBACK;
+
+				SET_RESULT_SUCCESS(0);
+				break;
+
+			default:
+				// Unknown operation
+				SET_FAILURE_INVALID_REQUEST();
+				break;
 		}
 
 		break;

--- a/packetWin7/npf/npf/Packet.h
+++ b/packetWin7/npf/npf/Packet.h
@@ -150,6 +150,8 @@ struct packet_file_header
 // Loopback behaviour definitions
 #define NPF_DISABLE_LOOPBACK				1	///< Tells the driver to drop the packets sent by itself. This is usefult when building applications like bridges.
 #define NPF_ENABLE_LOOPBACK					2	///< Tells the driver to capture the packets sent by itself.
+#define NPF_DISABLE_LOOPBACK_RX 3 ///< Tells the driver to not receive the packets sent by itself.
+#define NPF_ENABLE_LOOPBACK_RX 4 ///< Tells the driver to receive the packets sent by itself.
 
 // Admin only mode definition
 //#define NPF_ADMIN_ONLY_MODE			///< Tells the driver to restrict its access only to Administrators. This is used to support "Admin-only Mode" for Npcap.
@@ -410,7 +412,7 @@ typedef struct _OPEN_INSTANCE
 
 	OPEN_STATE OpenStatus;
 	NDIS_SPIN_LOCK			OpenInUseLock;
-
+	ULONG SendFlags; ///< Flags passed to NDIS send functions. See https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisfsendnetbufferlists.
 } 
 OPEN_INSTANCE, *POPEN_INSTANCE;
 

--- a/packetWin7/npf/npf/Write.c
+++ b/packetWin7/npf/npf/Write.c
@@ -101,7 +101,6 @@ NPF_Write(
 	PSINGLE_LIST_ENTRY Curr;
 	POPEN_INSTANCE		TempOpen;
 	PIO_STACK_LOCATION	IrpSp;
-	ULONG				SendFlags = 0;
 	PNET_BUFFER_LIST	pNetBufferList = NULL;
 	ULONG				NumSends;
 	ULONG				numSentPackets;
@@ -316,7 +315,6 @@ NPF_Write(
 
 			pNetBufferList->SourceHandle = Open->pFiltMod->AdapterHandle;
 			RESERVED(pNetBufferList)->ChildOpen = Open; //save the child open object in the packets
-			//SendFlags |= NDIS_SEND_FLAGS_CHECK_FOR_LOOPBACK;
 
 			// Recognize IEEE802.1Q tagged packet, as no many adapters support VLAN tag packet sending, no much use for end users,
 			// and this code examines the data which lacks efficiency, so I left it commented, the sending part is also unfinished.
@@ -388,7 +386,7 @@ NPF_Write(
 					NdisFSendNetBufferLists(Open->pFiltMod->AdapterHandle,
 						pNetBufferList,
 						NDIS_DEFAULT_PORT_NUMBER,
-						SendFlags);
+						Open->SendFlags);
 				}
 
 			numSentPackets ++;
@@ -458,7 +456,6 @@ NPF_BufferedWrite(
 	PIO_STACK_LOCATION		IrpSp;
 	PNET_BUFFER_LIST		pNetBufferList = NULL;
 	PNET_BUFFER				pNetBuffer;
-	ULONG					SendFlags = 0;
 	UINT					i;
 	NDIS_STATUS				Status;
 	LARGE_INTEGER			StartTicks, CurTicks, TargetTicks;
@@ -679,7 +676,6 @@ NPF_BufferedWrite(
 
 		pNetBufferList->SourceHandle = Open->pFiltMod->AdapterHandle;
 		RESERVED(pNetBufferList)->ChildOpen = Open; //save the child open object in the packets
-		//SendFlags |= NDIS_SEND_FLAGS_CHECK_FOR_LOOPBACK;
 
 		//
 		// Call the MAC
@@ -710,7 +706,7 @@ NPF_BufferedWrite(
 				NdisFSendNetBufferLists(Open->pFiltMod->AdapterHandle,
 					pNetBufferList,
 					NDIS_DEFAULT_PORT_NUMBER,
-					SendFlags);
+					Open->SendFlags);
 			}
 
 		// 


### PR DESCRIPTION
Fixes nmap/nmap#1343

Adjustable with PacketSetLoopbackBehavior.
Info about changes: https://docs.microsoft.com/en-us/windows-hardware/drivers/network/looping-back-ndis-packets