### PR TITLE
Fix usage of KeQuerySystemTimePrecise

### DIFF
--- a/packetWin7/npf/npf/Openclos.c
+++ b/packetWin7/npf/npf/Openclos.c
@@ -1656,7 +1656,7 @@ static NDIS_STATUS NPF_ValidateParameters(
 	{
 		if (MiniportMediaType != NdisMediumNative802_11)
 		{
-			IF_LOUD(DbgPrint("Unsupported media type for the WiFi filter: MiniportMediaType = %d, expected = 16 (NdisMediumNative802_11).\n", AttachParameters->MiniportMediaType);)
+			IF_LOUD(DbgPrint("Unsupported media type for the WiFi filter: MiniportMediaType = %d, expected = 16 (NdisMediumNative802_11).\n", MiniportMediaType);)
 
 			return NDIS_STATUS_INVALID_PARAMETER;
 		}

--- a/packetWin7/npf/npf/Packet.c
+++ b/packetWin7/npf/npf/Packet.c
@@ -281,6 +281,7 @@ DriverEntry(
 	NDIS_STRING strNdisGroupMaxProcessorCount;
 	NDIS_STRING strKeGetCurrentProcessorNumberEx;
 	NDIS_STRING strKeGetProcessorIndexFromNumber;
+	NDIS_STRING strKeQuerySystemTimePrecise;
 
 	UNREFERENCED_PARAMETER(RegistryPath);
 
@@ -377,6 +378,12 @@ DriverEntry(
 
 	RtlInitUnicodeString(&strKeGetCurrentProcessorNumberEx, L"KeGetCurrentProcessorNumberEx");
 	g_My_KeGetCurrentProcessorNumberEx = (KEGETCURRENTPROCESSORNUMBEREX) NdisGetRoutineAddress(&strKeGetCurrentProcessorNumberEx);
+
+	//
+	// Try to get reference to KeQuerySystemTimePrecise (Windows 8 and later)
+	//
+	RtlInitUnicodeString(&strKeQuerySystemTimePrecise, L"KeQuerySystemTimePrecise");
+	g_My_KeQuerySystemTimePrecise = (KEQUERYSYSTEMTIMEPRECISE) MmGetSystemRoutineAddress(&strKeQuerySystemTimePrecise);
 
 	//
 	// Get number of CPUs and save it

--- a/packetWin7/npf/npf/Packet.c
+++ b/packetWin7/npf/npf/Packet.c
@@ -206,24 +206,19 @@ My_KeGetCurrentProcessorNumber(
 	return Cpu;
 }
 
-typedef VOID (*KEQUERYSYSTEMTIMEPRECISE)(
-	PLARGE_INTEGER CurrentTime
-	);
-KEQUERYSYSTEMTIMEPRECISE g_My_KeQuerySystemTimePrecise = NULL;
+PQUERYSYSTEMTIME g_ptrQuerySystemTime = NULL;
 
-VOID My_KeQuerySystemTimePrecise(
+#ifdef KeQuerySystemTime
+// On Win x64, KeQuerySystemTime is defined as a macro,
+// this function wraps the macro execution.
+void
+KeQuerySystemTimeWrapper(
 	PLARGE_INTEGER CurrentTime
-	)
+)
 {
-	if (g_My_KeQuerySystemTimePrecise) // Windows 8 and newer
-	{
-		g_My_KeQuerySystemTimePrecise(CurrentTime);
-	}
-	else
-	{
-		KeQuerySystemTime(CurrentTime);
-	}
+	KeQuerySystemTime(CurrentTime);
 }
+#endif
 
 #ifdef NPCAP_READ_ONLY
 // For read-only Npcap, we want an explicit denial function for the Write call.
@@ -380,10 +375,19 @@ DriverEntry(
 	g_My_KeGetCurrentProcessorNumberEx = (KEGETCURRENTPROCESSORNUMBEREX) NdisGetRoutineAddress(&strKeGetCurrentProcessorNumberEx);
 
 	//
-	// Try to get reference to KeQuerySystemTimePrecise (Windows 8 and later)
+	// Initialize system-time function pointer.
 	//
 	RtlInitUnicodeString(&strKeQuerySystemTimePrecise, L"KeQuerySystemTimePrecise");
-	g_My_KeQuerySystemTimePrecise = (KEQUERYSYSTEMTIMEPRECISE) MmGetSystemRoutineAddress(&strKeQuerySystemTimePrecise);
+	g_ptrQuerySystemTime = (PQUERYSYSTEMTIME) MmGetSystemRoutineAddress(&strKeQuerySystemTimePrecise);
+	// If KeQuerySystemTimePrecise is not available,
+	// use KeQuerySystemTime function (Win32) or a wrapper to the KeQuerySystemTime macro (x64).
+	if (g_ptrQuerySystemTime == NULL) {
+#ifdef KeQuerySystemTime
+		g_ptrQuerySystemTime = &KeQuerySystemTimeWrapper;
+#else
+		g_ptrQuerySystemTime = &KeQuerySystemTime;
+#endif
+	}
 
 	//
 	// Get number of CPUs and save it

--- a/packetWin7/npf/npf/time_calls.h
+++ b/packetWin7/npf/npf/time_calls.h
@@ -102,13 +102,12 @@ __inline BOOLEAN NPF_TimestampModeSupported(ULONG mode)
 		|| mode == TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE;
 }
 
-extern ULONG g_TimestampMode;
-
-/* Defined in Packet.c/h
- * Falls back to KeQuerySystemTime (i.e. not Precise) on Win7/2008R2 */
-VOID My_KeQuerySystemTimePrecise(
+typedef void(*PQUERYSYSTEMTIME)(
 	PLARGE_INTEGER CurrentTime
 	);
+
+extern ULONG g_TimestampMode;
+extern PQUERYSYSTEMTIME g_ptrQuerySystemTime;
 
 /*!
   \brief A microsecond precise timestamp.
@@ -141,7 +140,7 @@ __inline void SynchronizeOnCpu(struct timeval* start)
 	// get the absolute value of the system boot time.   
 
 	PTime = KeQueryPerformanceCounter(&TimeFreq);
-	My_KeQuerySystemTimePrecise(&SystemTime);
+	g_ptrQuerySystemTime(&SystemTime);
 
 	start->tv_sec = (LONG)(SystemTime.QuadPart / 10000000 - 11644473600);
 
@@ -212,7 +211,7 @@ __inline void GetTimeQST_precise(struct timeval* dst)
 {
 	LARGE_INTEGER SystemTime;
 
-	My_KeQuerySystemTimePrecise(&SystemTime);
+	g_ptrQuerySystemTime(&SystemTime);
 
 	dst->tv_sec = (LONG)(SystemTime.QuadPart / 10000000 - 11644473600);
 	dst->tv_usec = (LONG)((SystemTime.QuadPart % 10000000) / 10);


### PR DESCRIPTION
Init pointer to KeQuerySystemTimePrecise.
Replace dispatcher function with if branch with direct function pointer as an improvement.