### PR TITLE
examples: build: support mingw build

### DIFF
--- a/Examples-pcap/UDPdump/GNUmakefile
+++ b/Examples-pcap/UDPdump/GNUmakefile
@@ -1,11 +1,12 @@
 # Makefile for cygwin gcc
 # Loris Degioanni
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = udpdump.o
-LIBS = -L ${PCAP_PATH} -lwpcap -lwsock32
+LIBS = -L ${PCAP_PATH} -lwpcap -lws2_32
 
 all: ${OBJS}
 	${CC} ${CFLAGS} -o udpdump.exe ${OBJS} ${LIBS}

--- a/Examples-pcap/basic_dump/GNUmakefile
+++ b/Examples-pcap/basic_dump/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = basic_dump.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/basic_dump_ex/GNUmakefile
+++ b/Examples-pcap/basic_dump_ex/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = basic_dump_ex.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/iflist/GNUmakefile
+++ b/Examples-pcap/iflist/GNUmakefile
@@ -1,11 +1,12 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = iflist.o
-LIBS = -L ${PCAP_PATH} -lwpcap
+LIBS = -L ${PCAP_PATH} -lwpcap -lws2_32
 
 all: ${OBJS}
 	${CC} ${CFLAGS} -o iflist.exe ${OBJS} ${LIBS}

--- a/Examples-pcap/pcap_filter/GNUmakefile
+++ b/Examples-pcap/pcap_filter/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = pcap_filter.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/pktdump_ex/GNUmakefile
+++ b/Examples-pcap/pktdump_ex/GNUmakefile
@@ -1,5 +1,6 @@
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = pktdump_ex.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/readfile/GNUmakefile
+++ b/Examples-pcap/readfile/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = readfile.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/readfile_ex/GNUmakefile
+++ b/Examples-pcap/readfile_ex/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = readfile_ex.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/savedump/GNUmakefile
+++ b/Examples-pcap/savedump/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = savedump.o
 LIBS = -L ${PCAP_PATH} -lwpcap

--- a/Examples-pcap/sendpack/GNUmakefile
+++ b/Examples-pcap/sendpack/GNUmakefile
@@ -1,8 +1,9 @@
 # Makefile for cygwin gcc
 # Nate Lawson <nate@rootlabs.com>
 
-PCAP_PATH = ../../lib
-CFLAGS = -g -O -mno-cygwin -I ../../include
+CYGWIN_FLAGS = -mno-cygwin
+PCAP_PATH = ../../Lib$(LIBARCH)
+CFLAGS = -g -O $(CYGWIN_FLAGS) -I ../../Include
 
 OBJS = sendpack.o
 LIBS = -L ${PCAP_PATH} -lwpcap


### PR DESCRIPTION
Currently cygwin build is supported, while cygwin is actually mingw, it has its own flags and settings to build native windows executables.

This change adds minimal support for mingw build keeping backward compatibility.

Changes:

* Case sensitive paths, the SDK uses Include and Lib directories, while build had include and lib.
* Move -mno-cygwin flag to CYGWIN_FLAGS so that it can be overridden, default remains the same.
* Add LIBARCH make variable to be able to link against a specific variant of library.
* Add missing winsock linkage when needed and convert existing to winsock2.

Build using mingw-w64 is supported using:

    make CC=x86_64-w64-mingw32-gcc CYGWIN_FLAGS= LIBARCH=/x64

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>