### PR TITLE
allow WlanHelper to communicate with Packet.dll

### DIFF
--- a/packetWin7/Dll/Packet32.cpp
+++ b/packetWin7/Dll/Packet32.cpp
@@ -616,12 +616,17 @@ static PCHAR NpcapGetAdapterID(_In_ LPCSTR AdapterName, _Out_opt_ PULONG pNpfOpe
 	const char *src = NULL;
 	ULONG NpfOpenFlags = 0;
 
-	if (0 != _strnicmp(AdapterName, WINPCAP_COMPAT_DEVICE_PREFIX, sizeof(WINPCAP_COMPAT_DEVICE_PREFIX) - 1)) {
+	if (0 == _strnicmp(AdapterName, WINPCAP_COMPAT_DEVICE_PREFIX, sizeof(WINPCAP_COMPAT_DEVICE_PREFIX) - 1)) {
+		src = AdapterName + sizeof(WINPCAP_COMPAT_DEVICE_PREFIX) - 1;
+	}
+	else if (0 == _strnicmp(AdapterName, NPF_DRIVER_COMPLETE_DEVICE_PREFIX, sizeof(NPF_DRIVER_COMPLETE_DEVICE_PREFIX - 1))) {
+		src = AdapterName + sizeof(NPF_DRIVER_COMPLETE_DEVICE_PREFIX) - 1;
+	}
+	else {
 		// Not expected format
 		SetLastError(ERROR_INVALID_NAME);
 		return NULL;
 	}
-	src = AdapterName + sizeof(WINPCAP_COMPAT_DEVICE_PREFIX) - 1;
 
 	// Look for tags (case sensitive)
 	// First the most common case: no tag or it's loopback


### PR DESCRIPTION
WlanHelper (1.71) always fails for commends which invoke functions from Packet.dll with the error message `Error: makeOIDRequest::My_PacketOpenAdapter(\Device\NPCAP\{2f39942d-8094-45e2-9909-cce31258d699}) error 0x7b
(to use this function, you need to check the "Support raw 802.11 traffic" option when installing Npcap)`.

The failure occurs in `NpcapGetAdapterID` which expects the adapter name to start with `\Device\NPF_`, whereas WlanHelper constructs the name passed to Packet.dll with the prefix `\Device\NPCAP\`.