### PR TITLE
New TIMESTAMPMODE for QPC without system start time

### DIFF
--- a/packetWin7/npf/npf/Packet.c
+++ b/packetWin7/npf/npf/Packet.c
@@ -1864,13 +1864,14 @@ static NTSTATUS funcBIOCGTIMESTAMPMODES(_In_ POPEN_INSTANCE pOpen,
 	// Need to at least deliver the number of modes
 	ULONG uNeeded = sizeof(ULONG);
 	static ULONG SupportedModes[] = {
-		0, // count of modes, 0 means not initialized yet
-		TIMESTAMPMODE_SINGLE_SYNCHRONIZATION,
-		TIMESTAMPMODE_QUERYSYSTEMTIME,
+		0 // count of modes, 0 means not initialized yet
+		, TIMESTAMPMODE_SINGLE_SYNCHRONIZATION
+		, TIMESTAMPMODE_QUERYSYSTEMTIME
 #if (NTDDI_VERSION >= NTDDI_WIN8)
 		// This is last and is not reported if not different than QST
-		TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE
+		, TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE
 #endif
+		, TIMESTAMPMODE_SINGLE_SYNCHRONIZATION_RELATIVE
 	};
 
 	// Initialize the count if not already done.

--- a/packetWin7/npf/npf/Packet.h
+++ b/packetWin7/npf/npf/Packet.h
@@ -348,6 +348,7 @@ typedef struct _NPCAP_FILTER_MODULE
 	LONG nTimestampQPC; // Opens wanting TIMESTAMPMODE_SINGLE_SYNCHRONIZATION
 	LONG nTimestampQST; // Opens wanting TIMESTAMPMODE_QUERYSYSTEMTIME
 	LONG nTimestampQST_Precise; // Opens wanting TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE
+	LONG nTimestampQPC_Relative; // Opens wanting TIMESTAMPMODE_SINGLE_SYNCHRONIZATION_RELATIVE
 
 	ULONG SupportedPacketFilters;
 	ULONG					MyPacketFilter;

--- a/packetWin7/npf/npf/time_calls.h
+++ b/packetWin7/npf/npf/time_calls.h
@@ -112,6 +112,7 @@
 #define TIMESTAMPMODE_QUERYSYSTEMTIME 2
 #define /* DEPRECATED */ TIMESTAMPMODE_RDTSC 3
 #define TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE 4
+#define TIMESTAMPMODE_SINGLE_SYNCHRONIZATION_RELATIVE 5
 #define /* DEPRECATED */ TIMESTAMPMODE_SYNCHRONIZATION_ON_CPU_NO_FIXUP 99
 
 #define TIMESTAMPMODE_UNSET ((ULONG) -1)
@@ -122,7 +123,8 @@ inline BOOLEAN NPF_TimestampModeSupported(_In_ ULONG mode)
 {
 	return mode == TIMESTAMPMODE_SINGLE_SYNCHRONIZATION
 		|| mode == TIMESTAMPMODE_QUERYSYSTEMTIME
-		|| mode == TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE;
+		|| mode == TIMESTAMPMODE_QUERYSYSTEMTIME_PRECISE
+		|| mode == TIMESTAMPMODE_SINGLE_SYNCHRONIZATION_RELATIVE;
 }
 
 inline void BestQuerySystemTime(
@@ -189,7 +191,7 @@ inline void GetTimevalFromPerfCount(
 	NT_ASSERT(TimeFreq.QuadPart != 0);
 	LONG tmp = (LONG)(PTime.QuadPart / TimeFreq.QuadPart);
 
-	//it should be only the normal case i.e. TIMESTAMPMODE_SINGLESYNCHRONIZATION
+	//it should be only the normal case i.e. TIMESTAMPMODE_SINGLESYNCHRONIZATION (or TIMESTAMPMODE_SINGLE_SYNCHRONIZATION_RELATIVE)
 	dst->tv_sec = start->tv_sec + tmp;
 	dst->tv_usec = start->tv_usec + (LONG)((PTime.QuadPart % TimeFreq.QuadPart) * 1000000 / TimeFreq.QuadPart);
 


### PR DESCRIPTION
This mode functions the same as `TIMESTAMPMODE_SINGLE_SYNCHRONIZATION` except the start time is set to zero. Thus the timestamp appears as "1970-01-01..." in Wireshark for example.

This is useful if an application wishes to synchronise packets with an external time source and is able to convert from QPC ticks to that time source. In the regular mode `TIMESTAMPMODE_SINGLE_SYNCHRONIZATION`, the driver start time must first be subtracted, which can only be approximated, substantially reducing accuracy. With this modification, high accuracy can be maintained.

I've named the new mode `TIMESTAMPMODE_SINGLE_SYNCHRONIZATION_RELATIVE` since the returned timestamps are relative to system boot time, but there may be better names. Similarly, it may be better to pass the timestamp mode into the call to `TIME_SYNCHRONIZE` and set the timeval to 0 there.